### PR TITLE
Include math.h for `round()`

### DIFF
--- a/src/Swr_Model.cpp
+++ b/src/Swr_Model.cpp
@@ -1,4 +1,4 @@
-
+#include <math.h>
 
 #include "Swr_Model.h"
 


### PR DESCRIPTION
Without this patch, it won't compile on my machine (Linux, gcc 7.3.1)

We should actually also link against `-lm` on some platforms, but I could not figure out how to do this easily with CMake. This works fine on my machine as-is.

I wonder if we even need the `round()` in the first place. [See my comment on the original patch](https://github.com/Olganix/Sw_Racer/commit/21110931b80afa76a2ed953d731d5ad0145e858b#r28853858).
(I did not read the surrounding code, test or look into this issue yet; but aligning up / ceiling sounds more realistic)