### PR TITLE
Hacky Data/LStr support

### DIFF
--- a/src/Collada.cpp
+++ b/src/Collada.cpp
@@ -589,6 +589,8 @@ TiXmlElement* Collada::createNode(string name, TiXmlElement* parentNode, Vector3
 
 	if (instanceGeometryName.length() != 0)
 		makeInstanceGeometryOnNode(node, instanceGeometryName, materialName, haveTexture);
+  else
+  	node->SetAttribute("type", "NODE");
 
 	return node;
 }


### PR DESCRIPTION
Implements support for the LStr chunk in the XML and Collada.
LStr represents lightsources / lensflares. I assume that LStr stands for "Light Streak"

Can be easily tested with a track such as model_232 which contains lights.

![Example in Blender with model_232](https://user-images.githubusercontent.com/360330/40382093-cdfd6e6c-5dfd-11e8-807c-402343c027c1.png)


Issues with this PR (which I won't fix):
- LStr nodes are generated before the rest of the collada chunks, this feels like bad design
- LStr nodes are not part of the model (which is fine, as they are relative to the root, but it still looks bad in hierarchy); can't fix due to previous issue
- LStr not supported in wxHexEditor tags, I felt duplicating work is stupid. We should instead redesign this tool to auto-generate wxHexEditor tags from the other code.
- Scen/Data is not supported (not really related to LStr support, but needed to touch it)
- Empty nodes still have a rotation (scale should be kept, as unit-scale is too small)
- Tabs vs. spaces